### PR TITLE
feat(order): 매수/매도/주문내역 API(MVP) + local(H2) 실행 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
     compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
+
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: trademill
+      POSTGRES_USER: tm
+      POSTGRES_PASSWORD: tm
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata: {}

--- a/src/main/java/trademill/apiserver/broker/BrokerGateway.java
+++ b/src/main/java/trademill/apiserver/broker/BrokerGateway.java
@@ -1,0 +1,12 @@
+package trademill.apiserver.broker;
+
+import java.math.BigDecimal;
+
+
+// BrokerGateway : '증권사와 어떻게 대화할지' 계약서(포트) 역할
+public interface BrokerGateway {
+    String placeMarketBuy(String symbol, BigDecimal quantity);
+    String placeMarketSell(String symbol, BigDecimal quantity);
+    String placeLimitBuy(String symbol, BigDecimal quantity, BigDecimal price);
+    String placeLimitSell(String symbol, BigDecimal quantity, BigDecimal price);
+}

--- a/src/main/java/trademill/apiserver/broker/FakeBrokerGateway.java
+++ b/src/main/java/trademill/apiserver/broker/FakeBrokerGateway.java
@@ -1,0 +1,20 @@
+package trademill.apiserver.broker;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Profile({"local","dev","default"})
+@Component
+
+// FakeBrokerGateway : 실제 증권사 호출 대신 로컬 개발/테스트용으로 응답을 꾸며주는 구현체(어댑터)
+public class FakeBrokerGateway implements BrokerGateway {
+    private String id(){ return "SIM-" + UUID.randomUUID(); }
+
+    public String placeMarketBuy(String s, BigDecimal q){ return id(); }
+    public String placeMarketSell(String s, BigDecimal q){ return id(); }
+    public String placeLimitBuy(String s, BigDecimal q, BigDecimal p){ return id(); }
+    public String placeLimitSell(String s, BigDecimal q, BigDecimal p){ return id(); }
+}

--- a/src/main/java/trademill/apiserver/order/Order.java
+++ b/src/main/java/trademill/apiserver/order/Order.java
@@ -1,0 +1,42 @@
+package trademill.apiserver.order;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "orders")
+@Getter @Setter @NoArgsConstructor
+public class Order {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private String symbol;
+
+    @Enumerated(EnumType.STRING) private OrderSide side;
+    @Enumerated(EnumType.STRING) private OrderType orderType;
+
+    private BigDecimal quantity;
+    private BigDecimal price; // MARKET이면 null 가능
+
+    @Enumerated(EnumType.STRING) private OrderStatus status;
+    private String brokerOrderId;
+
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        createdAt = OffsetDateTime.now();
+        updatedAt = createdAt;
+        if (status == null) status = OrderStatus.PENDING;
+    }
+    @PreUpdate
+    void onUpdate() { updatedAt = OffsetDateTime.now(); }
+}

--- a/src/main/java/trademill/apiserver/order/OrderController.java
+++ b/src/main/java/trademill/apiserver/order/OrderController.java
@@ -1,0 +1,33 @@
+package trademill.apiserver.order;
+
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.*;
+import trademill.apiserver.order.dto.*;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+public class OrderController {
+    private final OrderService service;
+    public OrderController(OrderService service){ this.service = service; }
+
+    @PostMapping("/buy")
+    public OrderResponse buy(@Valid @RequestBody PlaceOrderRequest req){
+        return OrderResponse.from(service.placeBuy(req));
+    }
+
+    @PostMapping("/sell")
+    public OrderResponse sell(@Valid @RequestBody PlaceOrderRequest req){
+        return OrderResponse.from(service.placeSell(req));
+    }
+
+    @GetMapping
+    public Page<OrderResponse> list(@RequestParam Long userId,
+                                    @RequestParam(defaultValue="0") int page,
+                                    @RequestParam(defaultValue="20") int size){
+        return service.list(userId, PageRequest.of(page, size, Sort.by("id").descending()))
+                .map(OrderResponse::from);
+    }
+}

--- a/src/main/java/trademill/apiserver/order/OrderRepository.java
+++ b/src/main/java/trademill/apiserver/order/OrderRepository.java
@@ -1,0 +1,8 @@
+package trademill.apiserver.order;
+
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    Page<Order> findByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/trademill/apiserver/order/OrderService.java
+++ b/src/main/java/trademill/apiserver/order/OrderService.java
@@ -1,0 +1,56 @@
+package trademill.apiserver.order;
+
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import trademill.apiserver.broker.BrokerGateway;
+import trademill.apiserver.order.dto.PlaceOrderRequest;
+
+@Service
+public class OrderService {
+    private final OrderRepository orders;
+    private final BrokerGateway broker;
+
+    public OrderService(OrderRepository orders, BrokerGateway broker) {
+        this.orders = orders;
+        this.broker = broker;
+    }
+
+    @Transactional
+    public Order placeBuy(PlaceOrderRequest req){
+        Order o = baseOf(req, OrderSide.BUY);
+        String id = switch (req.getOrderType()){
+            case MARKET -> broker.placeMarketBuy(req.getSymbol(), req.getQuantity());
+            case LIMIT  -> broker.placeLimitBuy(req.getSymbol(), req.getQuantity(), req.getPrice());
+        };
+        o.setBrokerOrderId(id); o.setStatus(OrderStatus.ACCEPTED);
+        return orders.save(o);
+    }
+
+    @Transactional
+    public Order placeSell(PlaceOrderRequest req){
+        Order o = baseOf(req, OrderSide.SELL);
+        String id = switch (req.getOrderType()){
+            case MARKET -> broker.placeMarketSell(req.getSymbol(), req.getQuantity());
+            case LIMIT  -> broker.placeLimitSell(req.getSymbol(), req.getQuantity(), req.getPrice());
+        };
+        o.setBrokerOrderId(id); o.setStatus(OrderStatus.ACCEPTED);
+        return orders.save(o);
+    }
+
+    public Page<Order> list(Long userId, Pageable pageable){
+        return orders.findByUserId(userId, pageable);
+    }
+
+    private Order baseOf(PlaceOrderRequest req, OrderSide side){
+        Order o = new Order();
+        o.setUserId(req.getUserId());
+        o.setSymbol(req.getSymbol());
+        o.setSide(side);
+        o.setOrderType(req.getOrderType());
+        o.setQuantity(req.getQuantity());
+        o.setPrice(req.getPrice());
+        o.setStatus(OrderStatus.PENDING);
+        return o;
+    }
+}

--- a/src/main/java/trademill/apiserver/order/OrderSide.java
+++ b/src/main/java/trademill/apiserver/order/OrderSide.java
@@ -1,0 +1,3 @@
+package trademill.apiserver.order;
+
+public enum OrderSide {BUY, SELL}

--- a/src/main/java/trademill/apiserver/order/OrderStatus.java
+++ b/src/main/java/trademill/apiserver/order/OrderStatus.java
@@ -1,0 +1,3 @@
+package trademill.apiserver.order;
+
+public enum OrderStatus {PENDING, ACCEPTED, PARTIALLY_FILLED, FILLED, REJECTED, CANCELED}

--- a/src/main/java/trademill/apiserver/order/OrderType.java
+++ b/src/main/java/trademill/apiserver/order/OrderType.java
@@ -1,0 +1,3 @@
+package trademill.apiserver.order;
+
+public enum OrderType {MARKET, LIMIT}

--- a/src/main/java/trademill/apiserver/order/dto/OrderResponse.java
+++ b/src/main/java/trademill/apiserver/order/dto/OrderResponse.java
@@ -1,0 +1,38 @@
+package trademill.apiserver.order.dto;
+
+import lombok.Data;
+import trademill.apiserver.order.*;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Data
+public class OrderResponse {
+    private Long id;
+    private Long userId;
+    private String symbol;
+    private OrderSide side;
+    private OrderType orderType;
+    private BigDecimal quantity;
+    private BigDecimal price;
+    private OrderStatus status;
+    private String brokerOrderId;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+    public static OrderResponse from(Order o) {
+        OrderResponse r = new OrderResponse();
+        r.setId(o.getId());
+        r.setUserId(o.getUserId());
+        r.setSymbol(o.getSymbol());
+        r.setSide(o.getSide());
+        r.setOrderType(o.getOrderType());
+        r.setQuantity(o.getQuantity());
+        r.setPrice(o.getPrice());
+        r.setStatus(o.getStatus());
+        r.setBrokerOrderId(o.getBrokerOrderId());
+        r.setCreatedAt(o.getCreatedAt());
+        r.setUpdatedAt(o.getUpdatedAt());
+        return r;
+    }
+}

--- a/src/main/java/trademill/apiserver/order/dto/PlaceOrderRequest.java
+++ b/src/main/java/trademill/apiserver/order/dto/PlaceOrderRequest.java
@@ -1,0 +1,17 @@
+package trademill.apiserver.order.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+import trademill.apiserver.order.OrderType;
+
+import java.math.BigDecimal;
+
+@Getter @Setter
+public class PlaceOrderRequest {
+    @NotNull private Long userId;
+    @NotBlank private String symbol;
+    @NotNull private OrderType orderType;            // MARKET or LIMIT
+    @NotNull @DecimalMin("0.00000001") private BigDecimal quantity;
+    @DecimalMin("0.0") private BigDecimal price;     // LIMIT일 때만 필요
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:tm;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+server:
+  port: 8080


### PR DESCRIPTION
## 작업 내용 (MVP)
- 엔드포인트
  - POST /api/v1/orders/buy  (시장가 매수)
  - POST /api/v1/orders/sell (지정가/시장가 매도)
  - GET  /api/v1/orders      (주문 내역 페이지네이션)
- 도메인: Order, Repository, Service, Controller 구성
- 로컬 실행: local 프로필(H2)로 구동 확인
- 임시 브로커: FakeBrokerGateway (brokerOrderId = SIM-****)

## 로컬 실행
./gradlew bootRun --args='--spring.profiles.active=local'

### 확인 예시
- 매수(MARKET)
  curl -X POST http://localhost:8080/api/v1/orders/buy \
    -H "Content-Type: application/json" \
    -d '{"userId":1,"symbol":"005930","orderType":"MARKET","quantity":10}'
- 매도(LIMIT)
  curl -X POST http://localhost:8080/api/v1/orders/sell \
    -H "Content-Type: application/json" \
    -d '{"userId":1,"symbol":"005930","orderType":"LIMIT","quantity":5,"price":70000}'
- 주문 내역
  curl "http://localhost:8080/api/v1/orders?userId=1&page=0&size=20"

## 다음 단계
- 내일 KIS(AppKey/Secret, CANO, 상품코드) 수령 후 KisBrokerGateway로 실주문 연동
- Docker(Postgres) 전환
- demo 엔티티(H2 예약어 충돌) 정리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새 기능
  * 주문 관리 REST API 추가: 매수/매도 주문 접수(MARKET/LIMIT), 요청 유효성 검사, 주문 상세 응답(상태/브로커 주문 ID/생성·수정 시각), 사용자별 주문 목록 페이징·정렬 조회

* 작업
  * 로컬 프로필에 인메모리 DB(H2) 기본 설정 추가
  * Docker Compose에 Postgres 16 데이터베이스 서비스와 영속 볼륨 도입
  * 런타임 데이터베이스 드라이버(PostgreSQL, H2) 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->