### PR TITLE
feat(broker): KIS 모의주문 연동 1차

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/trademill/apiserver/TrademillApiApplication.java
+++ b/src/main/java/trademill/apiserver/TrademillApiApplication.java
@@ -2,7 +2,11 @@ package trademill.apiserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import trademill.apiserver.config.KisProperties;
 
+
+@EnableConfigurationProperties(KisProperties.class)
 @SpringBootApplication
 public class TrademillApiApplication {
 

--- a/src/main/java/trademill/apiserver/broker/BrokerGateway.java
+++ b/src/main/java/trademill/apiserver/broker/BrokerGateway.java
@@ -1,0 +1,12 @@
+package trademill.apiserver.broker;
+
+import java.math.BigDecimal;
+
+
+// BrokerGateway : '증권사와 어떻게 대화할지' 계약서(포트) 역할
+public interface BrokerGateway {
+    String placeMarketBuy(String symbol, BigDecimal quantity);
+    String placeMarketSell(String symbol, BigDecimal quantity);
+    String placeLimitBuy(String symbol, BigDecimal quantity, BigDecimal price);
+    String placeLimitSell(String symbol, BigDecimal quantity, BigDecimal price);
+}

--- a/src/main/java/trademill/apiserver/broker/FakeBrokerGateway.java
+++ b/src/main/java/trademill/apiserver/broker/FakeBrokerGateway.java
@@ -1,0 +1,20 @@
+package trademill.apiserver.broker;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Profile({"local","dev","default"})
+@Component
+
+// FakeBrokerGateway : 실제 증권사 호출 대신 로컬 개발/테스트용으로 응답을 꾸며주는 구현체(어댑터)
+public class FakeBrokerGateway implements BrokerGateway {
+    private String id(){ return "SIM-" + UUID.randomUUID(); }
+
+    public String placeMarketBuy(String s, BigDecimal q){ return id(); }
+    public String placeMarketSell(String s, BigDecimal q){ return id(); }
+    public String placeLimitBuy(String s, BigDecimal q, BigDecimal p){ return id(); }
+    public String placeLimitSell(String s, BigDecimal q, BigDecimal p){ return id(); }
+}

--- a/src/main/java/trademill/apiserver/broker/FakeBrokerGateway.java
+++ b/src/main/java/trademill/apiserver/broker/FakeBrokerGateway.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 import java.math.BigDecimal;
 import java.util.UUID;
 
-@Profile({"local","dev","default"})
+@Profile({"local","default"})
 @Component
 
 // FakeBrokerGateway : 실제 증권사 호출 대신 로컬 개발/테스트용으로 응답을 꾸며주는 구현체(어댑터)

--- a/src/main/java/trademill/apiserver/broker/kis/KisBrokerGateway.java
+++ b/src/main/java/trademill/apiserver/broker/kis/KisBrokerGateway.java
@@ -1,0 +1,136 @@
+package trademill.apiserver.broker.kis;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import trademill.apiserver.broker.BrokerGateway;
+import trademill.apiserver.config.KisProperties;
+import trademill.apiserver.order.OrderSide;
+import trademill.apiserver.broker.kis.dto.KisResponse;
+import trademill.apiserver.broker.kis.dto.OrderCashOutput;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Component
+@Profile("kis")
+@RequiredArgsConstructor
+public class KisBrokerGateway implements BrokerGateway {
+
+    private static final Logger log = LoggerFactory.getLogger(KisBrokerGateway.class);
+
+    private final WebClient kisWebClient;
+    private final KisTokenService tokenService;
+    private final KisProperties props;
+
+    @Override
+    public String placeMarketBuy(String symbol, BigDecimal quantity) {
+        return place(OrderSide.BUY, "MARKET", symbol, quantity, null);
+    }
+
+    @Override
+    public String placeLimitBuy(String symbol, BigDecimal quantity, BigDecimal price) {
+        return place(OrderSide.BUY, "LIMIT", symbol, quantity, price);
+    }
+
+    @Override
+    public String placeMarketSell(String symbol, BigDecimal quantity) {
+        return place(OrderSide.SELL, "MARKET", symbol, quantity, null);
+    }
+
+    @Override
+    public String placeLimitSell(String symbol, BigDecimal quantity, BigDecimal price) {
+        return place(OrderSide.SELL, "LIMIT", symbol, quantity, price);
+    }
+
+    private String place(OrderSide side, String orderType, String symbol, BigDecimal qty, BigDecimal price) {
+        log.info("[KIS:{} {}] symbol={}, qty={}, price={}", side, orderType, symbol, qty, price);
+
+        // 0) 토큰
+        String token = tokenService.getAccessToken();
+
+        // 1) KIS 주문 바디 구성
+        //    ORD_DVSN: 00=지정가, 01=시장가
+        final String ordDvsn = "LIMIT".equals(orderType) ? "00" : "01";
+        final String ordUnpr = "MARKET".equals(orderType) ? "0" : price.toPlainString();
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("CANO", props.getCano());               // 계좌번호(앞 8자리)
+        body.put("ACNT_PRDT_CD", props.getAcntPrdtCd()); // 상품코드(보통 01)
+        body.put("PDNO", symbol);                        // 종목코드
+        body.put("ORD_DVSN", ordDvsn);
+        body.put("ORD_QTY", qty.toPlainString());
+        body.put("ORD_UNPR", ordUnpr);
+
+        // 2) 해시키 요청
+        String hashKey = requestHashKey(token, body);
+
+        // 3) 주문 요청
+        String trId = mapTrId(side, props.isVirtual()); // KIS는 현금주문 TR이 매수/매도로 구분됨
+        KisResponse<OrderCashOutput> resp = kisWebClient.post()
+                .uri("/uapi/domestic-stock/v1/trading/order-cash")
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(h -> {
+                    h.add("authorization", "Bearer " + token);
+                    h.add("appkey", props.getAppKey());
+                    h.add("appsecret", props.getAppSecret());
+                    h.add("tr_id", trId);
+                    h.add("custtype", "P"); // 개인
+                    h.add("hashkey", hashKey);
+                })
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(ParameterizedTypes.orderCashResponse())
+                .block();
+
+        if (resp == null) throw new IllegalStateException("KIS response is null");
+        if (!"0".equals(resp.getRt_cd())) {
+            throw new IllegalStateException("KIS error: " + resp.getMsg_cd() + " - " + resp.getMsg1());
+        }
+
+        String ordNo = resp.getOutput() != null ? resp.getOutput().getORD_NO() : null;
+        log.info("[KIS] rt_cd=0, ORD_NO={}", ordNo);
+        return ordNo != null ? ordNo : "KIS-NO-ORDER-NO";
+    }
+
+    private String requestHashKey(String token, Map<String, Object> body) {
+        Map<String, Object> resp = kisWebClient.post()
+                .uri("/uapi/hashkey")
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(h -> {
+                    h.add("authorization", "Bearer " + token);
+                    h.add("appkey", props.getAppKey());
+                    h.add("appsecret", props.getAppSecret());
+                })
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        Object hk = resp != null ? resp.get("HASH") : null;
+        if (hk == null) throw new IllegalStateException("Failed to get hashkey from KIS");
+        return hk.toString();
+    }
+
+    /** KIS 현금주문 TR 매핑 (모의/실전, 매수/매도) */
+    private String mapTrId(OrderSide side, boolean virtual) {
+        boolean buy = side == OrderSide.BUY;
+        if (virtual) {
+            return buy ? "VTTC0802U" : "VTTC0801U"; // 모의: 매수/매도
+        } else {
+            return buy ? "TTTC0802U" : "TTTC0801U"; // 실전: 매수/매도
+        }
+    }
+
+    /** WebClient 제네릭 응답 타입 헬퍼 */
+    static class ParameterizedTypes {
+        static org.springframework.core.ParameterizedTypeReference<KisResponse<OrderCashOutput>> orderCashResponse() {
+            return new org.springframework.core.ParameterizedTypeReference<>() {};
+        }
+    }
+}

--- a/src/main/java/trademill/apiserver/broker/kis/KisTokenService.java
+++ b/src/main/java/trademill/apiserver/broker/kis/KisTokenService.java
@@ -1,0 +1,50 @@
+package trademill.apiserver.broker.kis;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import trademill.apiserver.config.KisProperties;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Service
+@Profile("kis")
+@RequiredArgsConstructor
+public class KisTokenService {
+    private static final Logger log = LoggerFactory.getLogger(KisTokenService.class);
+
+    private final WebClient kisWebClient;
+    private final KisProperties props;
+
+    private volatile String cachedToken;
+    private volatile Instant expiresAt = Instant.EPOCH;
+
+    public String getAccessToken() {
+        if (cachedToken != null && Instant.now().isBefore(expiresAt.minusSeconds(30))) {
+            return cachedToken;
+        }
+        Map<String, Object> resp = kisWebClient.post()
+                .uri("/oauth2/tokenP")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of(
+                        "grant_type", "client_credentials",
+                        "appkey", props.getAppKey(),
+                        "appsecret", props.getAppSecret()
+                ))
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        String token = (String) resp.get("access_token");
+        Number exp = (Number) resp.getOrDefault("expires_in", 0);
+        this.cachedToken = token;
+        this.expiresAt = Instant.now().plusSeconds(exp.longValue());
+        log.info("[KIS] access_token issued, expires_in={}s", exp);
+        return token;
+    }
+}

--- a/src/main/java/trademill/apiserver/broker/kis/dto/KisResponse.java
+++ b/src/main/java/trademill/apiserver/broker/kis/dto/KisResponse.java
@@ -1,0 +1,11 @@
+package trademill.apiserver.broker.kis.dto;
+
+import lombok.Data;
+
+@Data
+public class KisResponse<T> {
+    private String rt_cd;   // "0" 성공, "1" 실패
+    private String msg_cd;
+    private String msg1;
+    private T output;
+}

--- a/src/main/java/trademill/apiserver/broker/kis/dto/OrderCashOutput.java
+++ b/src/main/java/trademill/apiserver/broker/kis/dto/OrderCashOutput.java
@@ -1,0 +1,9 @@
+package trademill.apiserver.broker.kis.dto;
+
+import lombok.Data;
+
+@Data
+public class OrderCashOutput {
+    // KIS 주문응답의 주문번호 필드 (문서 기준)
+    private String ORD_NO;
+}

--- a/src/main/java/trademill/apiserver/config/KisConfig.java
+++ b/src/main/java/trademill/apiserver/config/KisConfig.java
@@ -1,0 +1,21 @@
+package trademill.apiserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@Profile("kis")
+public class KisConfig {
+
+    @Bean
+    public WebClient kisWebClient(KisProperties props) {
+        return WebClient.builder()
+                .baseUrl(props.getBaseUrl())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/trademill/apiserver/config/KisConfig.java
+++ b/src/main/java/trademill/apiserver/config/KisConfig.java
@@ -1,13 +1,15 @@
 package trademill.apiserver.config;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
+@EnableConfigurationProperties(KisProperties.class)
 @Profile("kis")
 public class KisConfig {
 
@@ -15,7 +17,11 @@ public class KisConfig {
     public WebClient kisWebClient(KisProperties props) {
         return WebClient.builder()
                 .baseUrl(props.getBaseUrl())
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE + "; charset=UTF-8")
+                .defaultHeader("Accept", MediaType.APPLICATION_JSON_VALUE)
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(c -> c.defaultCodecs().maxInMemorySize(4 * 1024 * 1024))
+                        .build())
                 .build();
     }
 }

--- a/src/main/java/trademill/apiserver/config/KisProperties.java
+++ b/src/main/java/trademill/apiserver/config/KisProperties.java
@@ -1,0 +1,37 @@
+package trademill.apiserver.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kis")
+public class KisProperties {
+    private String baseUrl;
+    private String appKey;
+    private String appSecret;
+    private String cano;
+    private String acntPrdtCd;
+    private TrId trId = new TrId();
+
+    public static class TrId {
+        private String buy;
+        private String sell;
+        // getters/setters
+        public String getBuy() { return buy; }
+        public void setBuy(String buy) { this.buy = buy; }
+        public String getSell() { return sell; }
+        public void setSell(String sell) { this.sell = sell; }
+    }
+
+    // getters/setters
+    public String getBaseUrl() { return baseUrl; }
+    public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
+    public String getAppKey() { return appKey; }
+    public void setAppKey(String appKey) { this.appKey = appKey; }
+    public String getAppSecret() { return appSecret; }
+    public void setAppSecret(String appSecret) { this.appSecret = appSecret; }
+    public String getCano() { return cano; }
+    public void setCano(String cano) { this.cano = cano; }
+    public String getAcntPrdtCd() { return acntPrdtCd; }
+    public void setAcntPrdtCd(String acntPrdtCd) { this.acntPrdtCd = acntPrdtCd; }
+    public TrId getTrId() { return trId; }
+    public void setTrId(TrId trId) { this.trId = trId; }
+}

--- a/src/main/java/trademill/apiserver/config/KisProperties.java
+++ b/src/main/java/trademill/apiserver/config/KisProperties.java
@@ -1,37 +1,31 @@
 package trademill.apiserver.config;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Getter @Setter
 @ConfigurationProperties(prefix = "kis")
 public class KisProperties {
     private String baseUrl;
     private String appKey;
     private String appSecret;
-    private String cano;
-    private String acntPrdtCd;
-    private TrId trId = new TrId();
+    private String accountNo; // 예: 50151652-01
 
-    public static class TrId {
-        private String buy;
-        private String sell;
-        // getters/setters
-        public String getBuy() { return buy; }
-        public void setBuy(String buy) { this.buy = buy; }
-        public String getSell() { return sell; }
-        public void setSell(String sell) { this.sell = sell; }
+    public String getCano() {
+        if (accountNo == null) return null;
+        int idx = accountNo.indexOf('-');
+        return idx > 0 ? accountNo.substring(0, idx) : accountNo;
     }
 
-    // getters/setters
-    public String getBaseUrl() { return baseUrl; }
-    public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
-    public String getAppKey() { return appKey; }
-    public void setAppKey(String appKey) { this.appKey = appKey; }
-    public String getAppSecret() { return appSecret; }
-    public void setAppSecret(String appSecret) { this.appSecret = appSecret; }
-    public String getCano() { return cano; }
-    public void setCano(String cano) { this.cano = cano; }
-    public String getAcntPrdtCd() { return acntPrdtCd; }
-    public void setAcntPrdtCd(String acntPrdtCd) { this.acntPrdtCd = acntPrdtCd; }
-    public TrId getTrId() { return trId; }
-    public void setTrId(TrId trId) { this.trId = trId; }
+    public String getAcntPrdtCd() {
+        if (accountNo == null) return null;
+        int idx = accountNo.indexOf('-');
+        return idx > 0 ? accountNo.substring(idx + 1) : "01";
+    }
+
+    public boolean isVirtual() {
+        // 모의투자 여부 (base-url 에 vts 포함 시 true)
+        return baseUrl != null && baseUrl.contains("openapivts");
+    }
 }

--- a/src/main/java/trademill/apiserver/demo/domain/Demo.java
+++ b/src/main/java/trademill/apiserver/demo/domain/Demo.java
@@ -18,7 +18,7 @@ public class Demo {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false)
+    @Column(name = "val")
 	private String value;
 
 }

--- a/src/main/java/trademill/apiserver/order/Order.java
+++ b/src/main/java/trademill/apiserver/order/Order.java
@@ -1,0 +1,42 @@
+package trademill.apiserver.order;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "orders")
+@Getter @Setter @NoArgsConstructor
+public class Order {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private String symbol;
+
+    @Enumerated(EnumType.STRING) private OrderSide side;
+    @Enumerated(EnumType.STRING) private OrderType orderType;
+
+    private BigDecimal quantity;
+    private BigDecimal price; // MARKET이면 null 가능
+
+    @Enumerated(EnumType.STRING) private OrderStatus status;
+    private String brokerOrderId;
+
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        createdAt = OffsetDateTime.now();
+        updatedAt = createdAt;
+        if (status == null) status = OrderStatus.PENDING;
+    }
+    @PreUpdate
+    void onUpdate() { updatedAt = OffsetDateTime.now(); }
+}

--- a/src/main/java/trademill/apiserver/order/OrderController.java
+++ b/src/main/java/trademill/apiserver/order/OrderController.java
@@ -1,0 +1,33 @@
+package trademill.apiserver.order;
+
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.*;
+import trademill.apiserver.order.dto.*;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+public class OrderController {
+    private final OrderService service;
+    public OrderController(OrderService service){ this.service = service; }
+
+    @PostMapping("/buy")
+    public OrderResponse buy(@Valid @RequestBody PlaceOrderRequest req){
+        return OrderResponse.from(service.placeBuy(req));
+    }
+
+    @PostMapping("/sell")
+    public OrderResponse sell(@Valid @RequestBody PlaceOrderRequest req){
+        return OrderResponse.from(service.placeSell(req));
+    }
+
+    @GetMapping
+    public Page<OrderResponse> list(@RequestParam Long userId,
+                                    @RequestParam(defaultValue="0") int page,
+                                    @RequestParam(defaultValue="20") int size){
+        return service.list(userId, PageRequest.of(page, size, Sort.by("id").descending()))
+                .map(OrderResponse::from);
+    }
+}

--- a/src/main/java/trademill/apiserver/order/OrderRepository.java
+++ b/src/main/java/trademill/apiserver/order/OrderRepository.java
@@ -1,0 +1,8 @@
+package trademill.apiserver.order;
+
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    Page<Order> findByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/trademill/apiserver/order/OrderService.java
+++ b/src/main/java/trademill/apiserver/order/OrderService.java
@@ -1,0 +1,56 @@
+package trademill.apiserver.order;
+
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import trademill.apiserver.broker.BrokerGateway;
+import trademill.apiserver.order.dto.PlaceOrderRequest;
+
+@Service
+public class OrderService {
+    private final OrderRepository orders;
+    private final BrokerGateway broker;
+
+    public OrderService(OrderRepository orders, BrokerGateway broker) {
+        this.orders = orders;
+        this.broker = broker;
+    }
+
+    @Transactional
+    public Order placeBuy(PlaceOrderRequest req){
+        Order o = baseOf(req, OrderSide.BUY);
+        String id = switch (req.getOrderType()){
+            case MARKET -> broker.placeMarketBuy(req.getSymbol(), req.getQuantity());
+            case LIMIT  -> broker.placeLimitBuy(req.getSymbol(), req.getQuantity(), req.getPrice());
+        };
+        o.setBrokerOrderId(id); o.setStatus(OrderStatus.ACCEPTED);
+        return orders.save(o);
+    }
+
+    @Transactional
+    public Order placeSell(PlaceOrderRequest req){
+        Order o = baseOf(req, OrderSide.SELL);
+        String id = switch (req.getOrderType()){
+            case MARKET -> broker.placeMarketSell(req.getSymbol(), req.getQuantity());
+            case LIMIT  -> broker.placeLimitSell(req.getSymbol(), req.getQuantity(), req.getPrice());
+        };
+        o.setBrokerOrderId(id); o.setStatus(OrderStatus.ACCEPTED);
+        return orders.save(o);
+    }
+
+    public Page<Order> list(Long userId, Pageable pageable){
+        return orders.findByUserId(userId, pageable);
+    }
+
+    private Order baseOf(PlaceOrderRequest req, OrderSide side){
+        Order o = new Order();
+        o.setUserId(req.getUserId());
+        o.setSymbol(req.getSymbol());
+        o.setSide(side);
+        o.setOrderType(req.getOrderType());
+        o.setQuantity(req.getQuantity());
+        o.setPrice(req.getPrice());
+        o.setStatus(OrderStatus.PENDING);
+        return o;
+    }
+}

--- a/src/main/java/trademill/apiserver/order/OrderSide.java
+++ b/src/main/java/trademill/apiserver/order/OrderSide.java
@@ -1,0 +1,3 @@
+package trademill.apiserver.order;
+
+public enum OrderSide {BUY, SELL}

--- a/src/main/java/trademill/apiserver/order/OrderStatus.java
+++ b/src/main/java/trademill/apiserver/order/OrderStatus.java
@@ -1,0 +1,3 @@
+package trademill.apiserver.order;
+
+public enum OrderStatus {PENDING, ACCEPTED, PARTIALLY_FILLED, FILLED, REJECTED, CANCELED}

--- a/src/main/java/trademill/apiserver/order/OrderType.java
+++ b/src/main/java/trademill/apiserver/order/OrderType.java
@@ -1,0 +1,3 @@
+package trademill.apiserver.order;
+
+public enum OrderType {MARKET, LIMIT}

--- a/src/main/java/trademill/apiserver/order/dto/OrderResponse.java
+++ b/src/main/java/trademill/apiserver/order/dto/OrderResponse.java
@@ -1,0 +1,38 @@
+package trademill.apiserver.order.dto;
+
+import lombok.Data;
+import trademill.apiserver.order.*;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Data
+public class OrderResponse {
+    private Long id;
+    private Long userId;
+    private String symbol;
+    private OrderSide side;
+    private OrderType orderType;
+    private BigDecimal quantity;
+    private BigDecimal price;
+    private OrderStatus status;
+    private String brokerOrderId;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+    public static OrderResponse from(Order o) {
+        OrderResponse r = new OrderResponse();
+        r.setId(o.getId());
+        r.setUserId(o.getUserId());
+        r.setSymbol(o.getSymbol());
+        r.setSide(o.getSide());
+        r.setOrderType(o.getOrderType());
+        r.setQuantity(o.getQuantity());
+        r.setPrice(o.getPrice());
+        r.setStatus(o.getStatus());
+        r.setBrokerOrderId(o.getBrokerOrderId());
+        r.setCreatedAt(o.getCreatedAt());
+        r.setUpdatedAt(o.getUpdatedAt());
+        return r;
+    }
+}

--- a/src/main/java/trademill/apiserver/order/dto/PlaceOrderRequest.java
+++ b/src/main/java/trademill/apiserver/order/dto/PlaceOrderRequest.java
@@ -1,0 +1,17 @@
+package trademill.apiserver.order.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+import trademill.apiserver.order.OrderType;
+
+import java.math.BigDecimal;
+
+@Getter @Setter
+public class PlaceOrderRequest {
+    @NotNull private Long userId;
+    @NotBlank private String symbol;
+    @NotNull private OrderType orderType;            // MARKET or LIMIT
+    @NotNull @DecimalMin("0.00000001") private BigDecimal quantity;
+    @DecimalMin("0.0") private BigDecimal price;     // LIMIT일 때만 필요
+}

--- a/src/main/resources/application-kis.yml
+++ b/src/main/resources/application-kis.yml
@@ -1,6 +1,13 @@
+kis:
+  base-url: ${KIS_BASE_URL}
+  app-key: ${KIS_APP_KEY}
+  app-secret: ${KIS_APP_SECRET}
+  account-no: ${KIS_ACCOUNT_NO}
+
 spring:
   datasource:
-    url: jdbc:h2:mem:tm
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:tm;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
     username: sa
     password:
   jpa:
@@ -8,14 +15,11 @@ spring:
       ddl-auto: update
     properties:
       hibernate.jdbc.time_zone: UTC
+
+logging:
+  level:
+    org.springframework.web.reactive.function.client.ExchangeFunctions: DEBUG
+    reactor.netty.http.client: INFO
+
 server:
   port: 8080
-kis:
-  base-url: ${KIS_BASE_URL}
-  app-key: ${KIS_APP_KEY}
-  app-secret: ${KIS_APP_SECRET}
-  cano: ${KIS_CANO}
-  acnt-prdt-cd: ${KIS_ACNT_PRDT_CD}
-  tr-id:
-    buy: ${KIS_TR_ID_BUY}
-    sell: ${KIS_TR_ID_SELL}

--- a/src/main/resources/application-kis.yml
+++ b/src/main/resources/application-kis.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:tm
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate.jdbc.time_zone: UTC
+server:
+  port: 8080
+kis:
+  base-url: ${KIS_BASE_URL}
+  app-key: ${KIS_APP_KEY}
+  app-secret: ${KIS_APP_SECRET}
+  cano: ${KIS_CANO}
+  acnt-prdt-cd: ${KIS_ACNT_PRDT_CD}
+  tr-id:
+    buy: ${KIS_TR_ID_BUY}
+    sell: ${KIS_TR_ID_SELL}


### PR DESCRIPTION
## Summary
- KIS 모의주문 연동 1차 완료 (매수/매도, 시장가/지정가)
- kis 프로필 분리 및 환경변수 주입

## Changes
- Broker: KisBrokerGateway, KisTokenService 추가
- DTO: KisResponse, OrderCashOutput
- Config: KisConfig, KisProperties, application-kis.yml
- FakeBrokerGateway 프로필 정리(local/default)
- H2 runtimeOnly 추가 (로컬 부팅)
- Demo 엔티티 컬럼명 예약어 충돌 회피

## How to run
export KIS_BASE_URL="https://openapivts.koreainvestment.com:29443"
export KIS_APP_KEY="<APP_KEY>"
export KIS_APP_SECRET="<APP_SECRET>"
export KIS_ACCOUNT_NO="<계좌번호-상품코드 예: 50151652-01>"
SPRING_PROFILES_ACTIVE=kis ./gradlew bootRun

## How to test (curl)
# 시장가 매수
curl -X POST "http://localhost:8080/api/v1/orders/buy" \
  -H "Content-Type: application/json" \
  -d '{"userId":1,"symbol":"005930","orderType":"MARKET","quantity":1}'

# 지정가 매도
curl -X POST "http://localhost:8080/api/v1/orders/sell" \
  -H "Content-Type: application/json" \
  -d '{"userId":1,"symbol":"005930","orderType":"LIMIT","quantity":1,"price":70000}'

- 장외 시간에는 모의투자에서 `40580000(장종료)` 응답 확인됨.
- TR_ID: 모의 VTTC0802U/VTTC0801U, 실전 TTTC0802U/TTTC0801U


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새 기능
  * 주문 API 추가: 매수/매도 생성(시장가/지정가) 및 사용자별 주문 목록 페이지네이션 조회.
  * 브로커 연동: KIS 프로필에서 실제 주문 전송, 로컬/기본 프로필에서 시뮬레이션 응답 제공.
* 작업
  * WebFlux 및 H2 도입으로 경량 실행·개발 환경 개선.
  * KIS 관련 값을 외부 설정으로 관리하고 프로필별 애플리케이션 구성 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->